### PR TITLE
Fix for 'package was not found' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
     libcurl4-gnutls-dev \
     libcairo2-dev/unstable \
     libxt-dev \
-    libssl-dev
+    libssl-dev \
+	libxml2 \
+	libxml2-dev
 
 # Download and install shiny server
 RUN wget --no-verbose https://s3.amazonaws.com/rstudio-shiny-server-os-build/ubuntu-12.04/x86_64/VERSION -O "version.txt" && \


### PR DESCRIPTION
If you want to build your own Docker image, Dockerfile should include code for installation of libxml2 and libxml2-dev. The reason is that the R package tm depends on them. Otherwise, a 'package was not found' error message will result.